### PR TITLE
Fix theme toggle behavior and theming

### DIFF
--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,20 +1,155 @@
 "use client";
 
-import type { ComponentProps } from "react";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
-type ThemeProviderProps = ComponentProps<typeof NextThemesProvider>;
+const THEME_STORAGE_KEY = "ezc-theme";
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return (
-    <NextThemesProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-      {...props}
-    >
-      {children}
-    </NextThemesProvider>
-  );
+export type ThemeName = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: ThemeName;
+  resolvedTheme: ThemeName;
+  isDark: boolean;
+  isReady: boolean;
+  setTheme: (nextTheme: ThemeName) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function isStoredTheme(value: unknown): value is ThemeName {
+  return value === "light" || value === "dark";
+}
+
+function applyThemeClass(theme: ThemeName) {
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  root.setAttribute("data-theme", theme);
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.add("light");
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeName>("light");
+  const [isReady, setIsReady] = useState(false);
+  const userPreference = useRef<ThemeName | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (isStoredTheme(stored)) {
+      userPreference.current = stored;
+    } else {
+      userPreference.current = null;
+    }
+
+    const prefersDark = window.matchMedia(DARK_MEDIA_QUERY).matches;
+    const initialTheme: ThemeName = userPreference.current ?? (prefersDark ? "dark" : "light");
+
+    setThemeState(initialTheme);
+    applyThemeClass(initialTheme);
+    setIsReady(true);
+
+    const media = window.matchMedia(DARK_MEDIA_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (userPreference.current) {
+        return;
+      }
+
+      const nextTheme: ThemeName = event.matches ? "dark" : "light";
+      setThemeState(nextTheme);
+      applyThemeClass(nextTheme);
+    };
+
+    media.addEventListener("change", handleChange);
+
+    return () => {
+      media.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== THEME_STORAGE_KEY) {
+        return;
+      }
+
+      if (isStoredTheme(event.newValue)) {
+        userPreference.current = event.newValue;
+        setThemeState(event.newValue);
+        applyThemeClass(event.newValue);
+        return;
+      }
+
+      userPreference.current = null;
+      const prefersDark = window.matchMedia(DARK_MEDIA_QUERY).matches;
+      const nextTheme: ThemeName = prefersDark ? "dark" : "light";
+      setThemeState(nextTheme);
+      applyThemeClass(nextTheme);
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const setTheme = useCallback((nextTheme: ThemeName) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    userPreference.current = nextTheme;
+    window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    setThemeState(nextTheme);
+    applyThemeClass(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const nextTheme: ThemeName = theme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+  }, [setTheme, theme]);
+
+  const contextValue = useMemo<ThemeContextValue>(() => {
+    return {
+      theme,
+      resolvedTheme: theme,
+      isDark: theme === "dark",
+      isReady,
+      setTheme,
+      toggleTheme,
+    };
+  }, [isReady, setTheme, theme, toggleTheme]);
+
+  return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,21 +1,41 @@
-"use client";
-
-import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-import { MoonStar, SunMedium } from "lucide-react";
-import { Button } from "@/components/ui/button";
-
-export function ThemeToggle() {
-  const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
-
-  const handleToggle = () => {
-    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
-    setTheme(nextTheme);
-  };
-
+"use client";
+
+import { useTheme } from "@/components/providers/theme-provider";
+import { useEffect, useState } from "react";
+import { MoonStar, SunMedium } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { isDark, isReady, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const handleToggle = () => {
+    if (!isReady) {
+      return;
+    }
+    toggleTheme();
+  };
+
+  const showDarkState = mounted && isDark;
+  const icon = showDarkState ? <SunMedium className="h-5 w-5" aria-hidden /> : <MoonStar className="h-5 w-5" aria-hidden />;
+  const label = !mounted || !isReady ? "Toggle theme" : showDarkState ? "Use light theme" : "Use dark theme";
+
+  return (
+    <Button
+      variant="ghost"
+      size="md"
+      onClick={handleToggle}
+      aria-label={label}
+      className="gap-2 rounded-full border border-border-soft px-4 text-sm hover:bg-background-muted"
+    >
+      {icon}
+      <span>{label}</span>
+    </Button>
+  );
+}
+
   const isDark = mounted && resolvedTheme === "dark";
   const icon = isDark ? <SunMedium className="h-5 w-5" aria-hidden /> : <MoonStar className="h-5 w-5" aria-hidden />;
   const label = !mounted ? "Toggle theme" : isDark ? "Use light theme" : "Use dark theme";


### PR DESCRIPTION
## Summary
- replace the third-party theme provider with an internal context that syncs the document class, local storage, and system preference changes
- update the theme toggle to consume the new context, guard against premature toggles, and keep the UI labels in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15a6c2dec8330a9f0dc4ad72b8e10