### PR TITLE
Remove duplicate block from ThemeToggle component

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -36,15 +36,6 @@ export function ThemeToggle() {
   );
 }
 
-  const isDark = mounted && resolvedTheme === "dark";
-  const icon = isDark ? <SunMedium className="h-5 w-5" aria-hidden /> : <MoonStar className="h-5 w-5" aria-hidden />;
-  const label = !mounted ? "Toggle theme" : isDark ? "Use light theme" : "Use dark theme";
-
-  return (
-    <Button
-      variant="ghost"
-      size="md"
-      onClick={handleToggle}
       aria-label={label}
       className="gap-2 rounded-full border border-border-soft px-4 text-sm hover:bg-background-muted"
     >


### PR DESCRIPTION
## Summary
- remove the stray duplicated JSX block from `ThemeToggle` that caused the lint parser error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16283c95883309ca0b033eb546e88