### PR TITLE
Fix theme toggle component syntax issues

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useTheme } from "@/components/providers/theme-provider";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { MoonStar, SunMedium } from "lucide-react";
+
+import { useTheme } from "@/components/providers/theme-provider";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
@@ -11,16 +12,29 @@ export function ThemeToggle() {
 
   useEffect(() => setMounted(true), []);
 
+  const showDarkState = mounted && isDark;
+
+  const label = useMemo(() => {
+    if (!mounted || !isReady) {
+      return "Toggle theme";
+    }
+
+    return showDarkState ? "Use light theme" : "Use dark theme";
+  }, [isReady, mounted, showDarkState]);
+
   const handleToggle = () => {
     if (!isReady) {
       return;
     }
+
     toggleTheme();
   };
 
-  const showDarkState = mounted && isDark;
-  const icon = showDarkState ? <SunMedium className="h-5 w-5" aria-hidden /> : <MoonStar className="h-5 w-5" aria-hidden />;
-  const label = !mounted || !isReady ? "Toggle theme" : showDarkState ? "Use light theme" : "Use dark theme";
+  const icon = showDarkState ? (
+    <SunMedium className="h-5 w-5" aria-hidden="true" />
+  ) : (
+    <MoonStar className="h-5 w-5" aria-hidden="true" />
+  );
 
   return (
     <Button
@@ -28,6 +42,7 @@ export function ThemeToggle() {
       size="md"
       onClick={handleToggle}
       aria-label={label}
+      aria-pressed={showDarkState}
       className="gap-2 rounded-full border border-border-soft px-4 text-sm hover:bg-background-muted"
     >
       {icon}
@@ -35,7 +50,5 @@ export function ThemeToggle() {
     </Button>
   );
 }
-      <span>{label}</span>
-    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- remove duplicated JSX that was breaking ESLint parsing in the theme toggle component
- memoize the toggle label and add accessibility improvements while preserving functionality

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1675c1a8483308fe9716996a5bd74