### PR TITLE
Fix ThemeToggle component syntax error

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -52,4 +52,4 @@ export function ThemeToggle() {
     </Button>
   );
 }
-}
+


### PR DESCRIPTION
## Summary
- remove the stray closing brace in the ThemeToggle component to resolve parsing errors

## Testing
- npm run lint -- src/components/theme-toggle.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d16b4b2ae08330a72ed89b045b3166