### PR TITLE
Fix extra brace in compare drawer

### DIFF
--- a/src/components/compare/compare-drawer.tsx
+++ b/src/components/compare/compare-drawer.tsx
@@ -159,4 +159,4 @@ export function CompareDrawer() {
     </div>
   );
 }
-}
+


### PR DESCRIPTION
## Summary
- remove an extra closing brace from the compare drawer component so the file parses correctly

## Testing
- npm run lint
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d1bb8b0a888330b4ba6d31e635b455